### PR TITLE
Spectrum::Config::Focus throwing away base_url

### DIFF
--- a/lib/spectrum/config/focus.rb
+++ b/lib/spectrum/config/focus.rb
@@ -201,7 +201,7 @@ module Spectrum
         @hierarchy&.value_map || {}
       end
 
-      def spectrum(_ = nil, args = {})
+      def spectrum(base_url = nil, args = {})
         @get_null_facets&.call
         {
           uid: @id,


### PR DESCRIPTION
The method `focus` was throwing away the `base_url` argument,
resulting in a bunch of NoMethodErrors (`'+' not defined on nil`)
 when running in development mode. Change to use it when present.