### PR TITLE
Use focus.default_sort when appropriate

### DIFF
--- a/lib/spectrum/config/focus.rb
+++ b/lib/spectrum/config/focus.rb
@@ -9,7 +9,7 @@ module Spectrum
                     :placeholder, :warning, :description,
                     :category, :base,
                     :fields, :url, :filters, :sorts, :id_field, :solr_params,
-                    :highly_recommended, :base_url, :raw_config
+                    :highly_recommended, :base_url, :raw_config, :default_sort
 
 
       HREF_DATA = {
@@ -435,7 +435,7 @@ module Spectrum
       end
 
       def get_basic_sorts(request)
-        sorts.values.find { |sort| sort.uid == request.sort } || sorts.default
+        sorts.values.find { |sort| sort.uid == request.sort } || default_sort
       end
 
       def get_sorts(request)

--- a/lib/spectrum/config/source.rb
+++ b/lib/spectrum/config/source.rb
@@ -191,7 +191,7 @@ module Spectrum
           new_params['q'] = new_params['s.q'] unless new_params['q']
           new_params.delete('s.q')
         end
-        new_params['s.sort'] = (focus.sorts.values.find { |sort| sort.uid == request.sort } || focus.sorts.default).value
+        new_params['s.sort'] = (focus.sorts.values.find { |sort| sort.uid == request.sort } || focus.default_sort).value
 
         #   # LibraryWeb QuickSearch will pass us "search_field=all_fields",
         #   # which means to do a Summon search against 's.q'


### PR DESCRIPTION
Current code doesn't expose `focus.default_sort` at all, and calling
code uses `focus.sorts.default` which degenerates to the last entry
in the list of sorts.

This PR exposes focus.default_sort (which itself defaults to
focus.sorts.default if the default_sort is undefined in the configuration
file) and then uses it instead of `sorts.default` in calling code.